### PR TITLE
updated jcenter url to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <repositories>
         <repository>
             <id>jcenter</id>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Issue: Build fails with access denied error.
From January 13, 2020	HTTP requests to JCenter will be denied. Only HTTPS will be supported.
Reference: https://jfrog.com/blog/secure-jcenter-with-https/

This commit updates the url to https